### PR TITLE
Feature: 채팅화면과 캐릭터 선택 화면 추가

### DIFF
--- a/lib/components/custom_bottom_bar.dart
+++ b/lib/components/custom_bottom_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:storymate/components/theme.dart';
+import 'package:storymate/routes/app_routes.dart';
 
 class CustomBottomBar extends StatelessWidget {
   final int currentIndex;
@@ -34,6 +35,7 @@ class CustomBottomBar extends StatelessWidget {
           letterSpacing: -0.23,
         ),
         selectedItemColor: AppTheme.primaryColor,
+        unselectedItemColor: Colors.grey,
         items: [
           BottomNavigationBarItem(
             icon: SvgPicture.asset('assets/chat.svg'),
@@ -56,6 +58,7 @@ class CustomBottomBar extends StatelessWidget {
           switch (index) {
             case 0:
               // 대화하기 탭
+              Get.toNamed(AppRoutes.CHARACTER_SELECTION);
               break;
             case 1:
               // 홈 탭

--- a/lib/controllers/chat_controller.dart
+++ b/lib/controllers/chat_controller.dart
@@ -1,0 +1,21 @@
+import 'package:get/get.dart';
+import '../models/message.dart';
+
+class ChatController extends GetxController {
+  var messages = <Message>[].obs; // 메시지 리스트 (Obx로 반응형 처리)
+  var messageInput = ''.obs; // 입력값 (반응형 처리)
+
+  // 메시지 추가
+  void sendMessage() {
+    if (messageInput.value.trim().isNotEmpty) {
+      // 사용자 메시지 추가
+      messages.add(Message(content: messageInput.value, isUser: true));
+      messageInput.value = ''; // 입력값 초기화
+
+      // 간단한 자동 응답 추가
+      Future.delayed(Duration(seconds: 1), () {
+        messages.add(Message(content: "안녕하세요! 무엇을 도와드릴까요?", isUser: false));
+      });
+    }
+  }
+}

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,0 +1,6 @@
+class Message {
+  final String content;
+  final bool isUser;
+
+  Message({required this.content, required this.isUser});
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -7,9 +7,13 @@ import 'package:storymate/views/book_list_page.dart';
 import 'package:storymate/views/book_read_page.dart';
 import 'package:storymate/views/book_search_page.dart';
 import 'package:storymate/views/home_page.dart';
+import 'package:storymate/views/character_selection_screen.dart';
+import 'package:storymate/views/chat_screen.dart';
 
 class AppRoutes {
   static const HOME = '/';
+  static const CHARACTER_SELECTION = '/character_selection';
+  static const CHAT = '/chat';
 
   static final routes = [
     GetPage(
@@ -42,6 +46,15 @@ class AppRoutes {
     GetPage(
       name: '/memo',
       page: () => AddMemoPage(),
+    ), // 캐릭터 선택 화면
+    GetPage(
+      name: CHARACTER_SELECTION,
+      page: () => CharacterSelectionScreen(),
+    ),
+    // 채팅 화면
+    GetPage(
+      name: CHAT,
+      page: () => ChatScreen(),
     ),
   ];
 }

--- a/lib/views/character_selection_screen.dart
+++ b/lib/views/character_selection_screen.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:get/get.dart';
+import '../../components/custom_bottom_bar.dart';
+import '../../routes/app_routes.dart';
+
+class CharacterSelectionScreen extends StatelessWidget {
+  final List<Map<String, String>> characters = [
+    {"name": "팅커벨", "work": "피터팬"},
+    {"name": "신데렐라", "work": "신데렐라"},
+    {"name": "알라딘", "work": "알라딘"},
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(
+                '작품 속 인물과 이야기를 나눠보세요!',
+                style: TextStyle(
+                  fontFamily: 'Jua',
+                  color: Colors.black,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            Row(
+              children: [
+                SvgPicture.asset(
+                  'assets/message.svg', // 메시지 아이콘
+                  width: 16,
+                  height: 16,
+                  color: Color(0xFF9B9FD0),
+                ),
+                SizedBox(width: 4),
+                Text(
+                  '00개', // 메시지 갯수
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontFamily: 'Jua',
+                    color: Color(0xFF9B9FD0),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+        centerTitle: false,
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: "인물/작품으로 검색",
+                hintStyle: TextStyle(
+                  fontFamily: 'Jua',
+                  color: Color(0xFF9B9FD0),
+                ),
+                suffixIcon: Icon(Icons.search, color: Color(0xFF9B9FD0)),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(30),
+                  borderSide: BorderSide(color: Colors.purple),
+                ),
+                filled: true,
+                fillColor: Colors.white,
+              ),
+            ),
+          ),
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(16.0),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                crossAxisSpacing: 10,
+                mainAxisSpacing: 10,
+              ),
+              itemCount: characters.length,
+              itemBuilder: (context, index) {
+                final character = characters[index];
+                return GestureDetector(
+                  onTap: () {
+                    // 선택한 캐릭터로 이동
+                    Get.toNamed(
+                      AppRoutes.CHAT,
+                      arguments: character["name"],
+                    );
+                  },
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          border: Border.all(color: Colors.grey, width: 2),
+                        ),
+                        child: CircleAvatar(
+                          radius: 40,
+                          backgroundColor: Colors.grey.shade200,
+                          child: Text(
+                            character["name"]![0],
+                            style: TextStyle(
+                              fontSize: 24,
+                              color: Colors.black,
+                              fontFamily: 'Jua',
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                      SizedBox(height: 8),
+                      Text(
+                        character["name"]!,
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontFamily: 'Jua',
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        character["work"]!,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontFamily: 'Jua',
+                          color: Colors.grey,
+                        ),
+                      ),
+                      SizedBox(height: 4),
+                      Container(
+                        decoration: BoxDecoration(
+                          color: Color(0xFF9B9FD0),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.favorite,
+                              color: Colors.white,
+                              size: 16,
+                            ),
+                            SizedBox(width: 4),
+                            Text(
+                              '00',
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontFamily: 'Jua',
+                                color: Colors.white,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: CustomBottomBar(
+        currentIndex: 1, // 대화하기 탭
+      ),
+    );
+  }
+}

--- a/lib/views/chat_bubble.dart
+++ b/lib/views/chat_bubble.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import '../models/message.dart';
+
+class ChatBubble extends StatelessWidget {
+  final Message message;
+
+  // 생성자
+  const ChatBubble({required this.message, Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isUser = message.isUser;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+        padding: EdgeInsets.all(10),
+        decoration: BoxDecoration(
+          color: isUser ? Color(0xFF9B9FD0) : Colors.grey[300], // 사용자/시스템 색상 구분
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(10),
+            topRight: Radius.circular(10),
+            bottomLeft: isUser ? Radius.circular(10) : Radius.zero,
+            bottomRight: isUser ? Radius.zero : Radius.circular(10),
+          ),
+        ),
+        child: Text(
+          message.content,
+          style: TextStyle(
+            color: isUser ? Colors.white : Colors.black,
+            fontSize: 16,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/chat_screen.dart
+++ b/lib/views/chat_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../controllers/chat_controller.dart';
+import 'package:storymate/views/chat_bubble.dart';
+
+class ChatScreen extends StatelessWidget {
+  const ChatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final ChatController controller =
+        Get.put(ChatController()); // controller 연결
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: Text("대화하기"),
+        backgroundColor: Color(0xFF9B9FD0), // AppBar 색상
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          // 채팅 메시지 리스트
+          Expanded(
+            child: Obx(() => ListView.builder(
+                  reverse: true,
+                  itemCount: controller.messages.length,
+                  itemBuilder: (context, index) {
+                    final message =
+                        controller.messages.reversed.toList()[index];
+                    return ChatBubble(message: message); // 메시지 UI
+                  },
+                )),
+          ),
+          // 입력창
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Obx(
+                    () => TextField(
+                      onChanged: (value) =>
+                          controller.messageInput.value = value,
+                      decoration: InputDecoration(
+                        hintText: '메시지를 입력하세요',
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          borderSide: BorderSide(color: Color(0xFF9B9FD0)),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          borderSide:
+                              BorderSide(color: Color(0xFF9B9FD0), width: 2.0),
+                        ),
+                      ),
+                      controller: TextEditingController()
+                        ..text = controller.messageInput.value
+                        ..selection = TextSelection.fromPosition(
+                          TextPosition(
+                              offset: controller.messageInput.value.length),
+                        ),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.send, color: Color(0xFF9B9FD0)),
+                  onPressed: controller.sendMessage,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
##📋 Description
대화하기 버튼 클릭 캐릭터 선택 화면으로 이동하도록 구현. (app_routes 수정)

캐릭터 선택 화면 구현 (character_selection_screen)
-- 캐릭터를 선택할 수 있는 그리드 레이아웃 구현.
-- 각 캐릭터 카드 클릭 시 해당 캐릭터 이름을 인수로 전달하며 채팅 화면으로 이동.

채팅 화면(Chat Screen)

-- 사용자가 메시지를 입력하고 전송할 수 있는 UI 구현.
-- 사용자의 메시지와 캐릭터의 응답 메시지를 구분하여 화면에 표시.
-- 메시지를 표시하는 ChatBubble 위젯 추가.

채팅 화면(Chat Screen) 및 캐릭터 선택 화면(Character Selection Screen) 구현
-- 캐릭터 선택 화면에서 각 캐릭터를 선택하면 채팅 화면으로 이동하도록 구현.
-- 채팅 화면은 입력된 메시지를 전송하고, 메시지를 UI로 표시할 수 있도록 구성.
-- 채팅 화면 관련 컨트롤러(ChatController)와 모델(Message) 추가
--- ChatController: 메시지 상태 관리(GetX 사용).
--- Message 모델: 메시지의 내용과 발신자 정보를 관리.
##📸 ScreenShot
구현한 화면 캡쳐본

캐릭터 선택 화면
<img width="407" alt="캐릭터 선택 화면" src="https://github.com/user-attachments/assets/5ca00815-5a7d-41a3-87cc-638150804d84" />

채팅화면
<img width="405" alt="채팅화면" src="https://github.com/user-attachments/assets/e0ff1c2b-38f8-4c9c-975f-87c09bb6e3e7" />

##💬 to Reviewers
채팅화면
추가로 공유할 내용
대화하기 버튼으로 화면 전환 시 버튼 색상 변경이 적용되지 않아, 추후 수정이 필요할 것 같습니다.
현재 반응형 레이아웃으로 구현했으나, 공통적인 반응형 스타일을 맞추는 논의가 필요해 보입니다.
추가해야 할 기능들
-- 서버 연결
-- 캐릭터 선택화면 검색 기능 구현